### PR TITLE
Add typeahead state input and autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1563,7 +1562,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1623,7 +1621,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2149,7 +2146,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2436,7 +2432,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2504,7 +2499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3072,7 +3066,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5455,7 +5448,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5465,7 +5457,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6154,7 +6145,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6317,7 +6307,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6593,7 +6582,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useGame } from '../hooks/useGame';
 import { CellState, State } from '../lib/gameLogic';
 
@@ -59,6 +60,17 @@ const td: React.CSSProperties = {
 
 export default function Home() {
   const { guesses, selected, setSelected, submitGuess, isWon, remaining } = useGame();
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  const query = selected.trim().toLowerCase();
+  const suggestions = query
+    ? remaining
+        .filter(s => {
+          const words = s.name.toLowerCase().split(/\s+/);
+          return words.some(w => w.startsWith(query));
+        })
+        .slice(0, 12)
+    : [];
 
   return (
     <main style={{ padding: 32, fontFamily: 'monospace' }}>
@@ -98,23 +110,66 @@ export default function Home() {
           Got it in {guesses.length} guess{guesses.length !== 1 ? 'es' : ''}!
         </p>
       ) : (
-        <div style={{ display: 'flex', gap: 8 }}>
-          <select
-            value={selected}
-            onChange={e => setSelected(e.target.value)}
-            style={{ padding: '8px 12px', fontSize: 15 }}
-          >
-            <option value="">— pick a state —</option>
-            {remaining.map(s => (
-              <option key={s.name} value={s.name}>{s.name}</option>
-            ))}
-          </select>
-          <button
-            onClick={submitGuess}
-            style={{ padding: '8px 20px', fontSize: 15, cursor: 'pointer' }}
-          >
-            Guess
-          </button>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+          <div style={{ position: 'relative' }}>
+            <input
+              value={selected}
+              placeholder="Type a state..."
+              onChange={e => {
+                setSelected(e.target.value);
+                setIsPickerOpen(true);
+              }}
+              onFocus={() => setIsPickerOpen(true)}
+              onBlur={() => {
+                // Let suggestion clicks land before closing.
+                window.setTimeout(() => setIsPickerOpen(false), 120);
+              }}
+              style={{
+                padding: '8px 12px',
+                fontSize: 15,
+                width: 220,
+                border: '1px solid #999',
+                borderRadius: 4,
+                background: '#fff',
+              }}
+            />
+            {isPickerOpen && suggestions.length > 0 && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 'calc(100% + 6px)',
+                  left: 0,
+                  right: 0,
+                  background: '#fff',
+                  border: '1px solid #999',
+                  boxShadow: '0 8px 20px rgba(0,0,0,0.12)',
+                  zIndex: 10,
+                  maxHeight: 240,
+                  overflowY: 'auto',
+                }}
+              >
+                {suggestions.map(s => (
+                  <div
+                    key={s.name}
+                    onMouseDown={e => {
+                      e.preventDefault();
+                      submitGuess(s.name);
+                      setIsPickerOpen(false);
+                    }}
+                    style={{
+                      padding: '8px 10px',
+                      cursor: 'pointer',
+                      borderBottom: '1px solid #eee',
+                      fontSize: 14,
+                      background: '#fff',
+                    }}
+                  >
+                    {s.name}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </main>

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -14,9 +14,10 @@ export function useGame() {
   const guessedNames = new Set(guesses.map(g => g.state.name));
   const remaining = (statesData as State[]).filter(s => !guessedNames.has(s.name));
 
-  function submitGuess() {
-    if (!selected) return;
-    const state = (statesData as State[]).find(s => s.name === selected);
+  function submitGuess(name?: string) {
+    const guessName = name ?? selected;
+    if (!guessName) return;
+    const state = (statesData as State[]).find(s => s.name === guessName);
     if (!state) return;
     setGuesses(prev => [...prev, compareGuess(state, target)]);
     setSelected('');


### PR DESCRIPTION
## Summary
- Replace the “pick a state” select with a text input that filters remaining states as you type.
- Clicking a suggestion immediately submits the guess and clears the input; the Guess button is removed.
- Matching checks each word in the state name so typing “Jersey” finds “New Jersey”, etc.

## Test plan
- Run `npm run dev`.
- Open `http://localhost:3000`.
- Type partial state names (including second words) and verify suggestions appear only from remaining states.
- Click a suggestion and confirm a new guess row is added and the input clears.