### PR TITLE
Feature: Implement inline ghost text suggestion and tab-to-autocomplete

### DIFF
--- a/src/components/StateSearch.tsx
+++ b/src/components/StateSearch.tsx
@@ -64,8 +64,17 @@ export function StateSearch({ value, remaining, onChange, onSubmit }: StateSearc
           })
           .slice(0, 12);
 
+  // Ghost text: show first suggestion whose name starts with the typed value
+  const ghostMatch =
+    query !== "" ? suggestions.find((s) => s.name.toLowerCase().startsWith(query)) : undefined;
+  const ghostText = ghostMatch ? value + ghostMatch.name.slice(value.length) : "";
+
   return (
     <div className="relative w-full max-w-sm mb-6">
+      {/* Ghost suggestion layer (behind) */}
+      <div className="w-full px-3 py-2 text-base text-gray-600 pointer-events-none whitespace-nowrap overflow-hidden select-none border border-transparent rounded" aria-hidden="true">
+        {ghostText || "\u00A0"}
+      </div>
       <input
         value={value}
         placeholder="Type a state..."
@@ -78,7 +87,21 @@ export function StateSearch({ value, remaining, onChange, onSubmit }: StateSearc
           // Let suggestion clicks land before closing.
           window.setTimeout(() => setIsPickerOpen(false), 120);
         }}
-        className="w-full px-3 py-2 text-base bg-gray-900 text-white border border-gray-600 rounded outline-none placeholder-gray-500 focus:border-blue-400"
+        onKeyDown={(e) => {
+          if (e.key === "Tab" && suggestions.length > 0) {
+            e.preventDefault();
+            onChange(suggestions[0].name);
+          } else if (e.key === "Enter") {
+            const exact = remaining.find(
+              (s) => s.name.toLowerCase() === value.trim().toLowerCase()
+            );
+            if (exact) {
+              onSubmit(exact.name);
+              setIsPickerOpen(false);
+            }
+          }
+        }}
+        className="absolute inset-0 w-full px-3 py-2 text-base bg-transparent text-white border border-gray-600 rounded outline-none placeholder-gray-500 focus:border-blue-400"
       />
       {isPickerOpen && suggestions.length > 0 && (
         <div className="absolute z-10 mt-1 w-full max-h-80 overflow-y-auto bg-gray-900 border border-gray-700 rounded shadow-lg">


### PR DESCRIPTION
**Description:**
This PR introduces a major UX enhancement to the state search bar by adding "ghost text" inline suggestions and keyboard-first navigation.

To make the core gameplay loop as frictionless as possible, players no longer need to use their mouse or arrow keys to select a state from the dropdown. As they type, the remainder of the closest matching state is displayed inline as faded gray text. Players can press `Tab` to securely autocomplete their input, and `Enter` to submit their guess, completely preventing accidental submissions while typing rapidly.

**Changes Included:**

* Built a layered input component using `position: relative` and `absolute` to cleanly render the gray "ghost text" directly behind the user's active, transparent `<input>`.
* Implemented real-time string matching to dynamically update the ghost text as the user types.
* Added an `onKeyDown` event listener to handle specific keyboard actions:
* **`Tab`**: Intercepts the default browser focus shift, autocompletes the input with the suggested state, and clears the ghost text.
* **`Enter`**: Validates the current input against the states list, triggers the `submitGuess` function, and resets the input UI for the next turn.


* Ensured edge cases (like empty inputs or typing a string with no matching states) gracefully hide the ghost text.

**Type of Change:**

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] UI/UX enhancement
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**

* [x] Ghost text correctly aligns with user input and updates in real-time.
* [x] `Tab` successfully auto-fills the input without shifting focus away from the search bar.
* [x] `Enter` only submits if the typed text matches a valid state.
* [x] Ghost text element has `pointer-events: none` so it doesn't block the user from clicking into the active input field.

**Related Issue:** Closes #17 